### PR TITLE
fix: prevent iOS crash when audio download fails in playFromUrl

### DIFF
--- a/src/audio/player.ios.ts
+++ b/src/audio/player.ios.ts
@@ -203,7 +203,7 @@ export class TNSPlayer extends Observable {
                         if (this.errorCallback) {
                             this.errorCallback({ error });
                         }
-                        reject(error);
+                        return reject(error);
                     }
                     const errorRef = new interop.Reference<NSError>();
                     const inputSource = SFBInputSource.inputSourceWithData(data);


### PR DESCRIPTION
## Problem

On iOS, `TNSPlayer.playFromUrl` crashes when the audio download fails. In the `NSURLSession.dataTaskWithURLCompletionHandler` callback, an error is handled by rejecting the promise — but execution **does not stop**, so it falls through to:

```ts
if (error !== null) {
    if (this.errorCallback) {
        this.errorCallback({ error });
    }
    reject(error);          // ← no return
}
const errorRef = new interop.Reference<NSError>();
const inputSource = SFBInputSource.inputSourceWithData(data);  // data is null → crash
```

When the request errors, `data` is `null`, so `SFBInputSource.inputSourceWithData(data)` (and the decoder init that follows) runs on invalid data and crashes the app. This shows up in practice as a crash/error when navigating away mid-load or when a track fails to download.

## Fix

Return after rejecting so the handler bails out cleanly on error:

```diff
-                        reject(error);
+                        return reject(error);
```

One line, `src/audio/player.ios.ts`. The other error branches in this handler already `return reject(...)`; this makes the download-error branch consistent with them.

## Testing

We've been running this exact change in production (iOS) via `patch-package` against `@nativescript-community/audio@6.4.14`, and it resolves the crash. The change is a control-flow guard only — no behavior change on the success path.